### PR TITLE
Add placeholder Astartes chapter subraces

### DIFF
--- a/src/astartes.c
+++ b/src/astartes.c
@@ -161,39 +161,66 @@ static void _get_flags(u32b flgs[OF_ARRAY_SIZE]) {
     }
 }
 
-static race_t *_greyknight_get_race_t(void)
+static race_t *_astartes_template(int which, cptr name, cptr desc)
 {
-    static race_t me = {0};
-    static bool   init = FALSE;
+    static race_t me[ASTARTES_MAX] = {{0}};
+    static bool   init[ASTARTES_MAX] = {FALSE};
+    race_t       *r = &me[which];
 
-    if (!init)
+    if (!init[which])
     {           /* dis, dev, sav, stl, srh, fos, thn, thb */
     skills_t bs = { 25,  35,  40,   3,  18,  12,  48,  35};
     skills_t xs = {  7,  13,  15,   0,   0,   0,  18,  13};
 
-        me.skills = bs;
-        me.extra_skills = xs;
+        r->skills = bs;
+        r->extra_skills = xs;
 
-        me.infra = 3;
-        me.exp = 325; /* 14.6 Mxp */
-        me.base_hp = 26;
+        r->infra = 3;
+        r->exp = 325; /* 14.6 Mxp */
+        r->base_hp = 26;
 
-        me.get_spells = _get_spells;
-        me.calc_bonuses = _calc_bonuses;
-        me.get_flags = _get_flags;
-        init = TRUE;
+        r->get_spells = _get_spells;
+        r->calc_bonuses = _calc_bonuses;
+        r->get_flags = _get_flags;
+        init[which] = TRUE;
     }
 
-    me.subname = "Grey Knight";
-    me.stats[A_STR] = 1 + p_ptr->lev/10;
-    me.stats[A_INT] = 1 + p_ptr->lev/10;
-    me.stats[A_WIS] = 4 + p_ptr->lev/10;
-    me.stats[A_DEX] = 1 + p_ptr->lev/10;
-    me.stats[A_CON] = 1 + p_ptr->lev/10;
-    me.stats[A_CHR] = 1 + p_ptr->lev/8;
-    me.life = 90 + p_ptr->lev;
+    r->subname = name;
+    r->subdesc = desc;
+    r->stats[A_STR] = 1 + p_ptr->lev/10;
+    r->stats[A_INT] = 1 + p_ptr->lev/10;
+    r->stats[A_WIS] = 4 + p_ptr->lev/10;
+    r->stats[A_DEX] = 1 + p_ptr->lev/10;
+    r->stats[A_CON] = 1 + p_ptr->lev/10;
+    r->stats[A_CHR] = 1 + p_ptr->lev/8;
+    r->life = 90 + p_ptr->lev;
 
-    return &me;
+    return r;
+}
+
+static race_t *_ultramarine_get_race_t(void)
+{
+    return _astartes_template(ASTARTES_ULTRAMARINE, "Ultramarine", "Placeholder for the Ultramarine chapter.");
+}
+
+static race_t *_greyknight_get_race_t(void)
+{
+    return _astartes_template(ASTARTES_GREY_KNIGHT, "Grey Knight", "Placeholder for the Grey Knight chapter.");
+}
+
+static race_t *_blacktemplar_get_race_t(void)
+{
+    return _astartes_template(ASTARTES_BLACK_TEMPLAR, "Black Templar", "Placeholder for the Black Templar chapter.");
+}
+
+static race_t *_thousandsons_get_race_t(void)
+{
+    return _astartes_template(ASTARTES_THOUSAND_SONS, "Thousand Sons", "Placeholder for the Thousand Sons chapter.");
+}
+
+static race_t *_blacklegion_get_race_t(void)
+{
+    return _astartes_template(ASTARTES_BLACK_LEGION, "Black Legion", "Placeholder for the Black Legion chapter.");
 }
 
 static caster_info * _caster_info(void)
@@ -215,13 +242,27 @@ static caster_info * _caster_info(void)
 /**********************************************************************
  * Public
  **********************************************************************/
-race_t *mon_astartes_get_race(void)
+race_t *mon_astartes_get_race(int psubrace)
 {
     race_t *result = NULL;
 
-    switch (p_ptr->psubrace)
+    switch (psubrace)
     {
-    /* TODO: Fallen Angel ? */
+    case ASTARTES_ULTRAMARINE:
+        result = _ultramarine_get_race_t();
+        break;
+    case ASTARTES_GREY_KNIGHT:
+        result = _greyknight_get_race_t();
+        break;
+    case ASTARTES_BLACK_TEMPLAR:
+        result = _blacktemplar_get_race_t();
+        break;
+    case ASTARTES_THOUSAND_SONS:
+        result = _thousandsons_get_race_t();
+        break;
+    case ASTARTES_BLACK_LEGION:
+        result = _blacklegion_get_race_t();
+        break;
     default: /* Birth Menus */
         result = _greyknight_get_race_t();
     }
@@ -235,12 +276,6 @@ race_t *mon_astartes_get_race(void)
     result->shop_adjust = 90;
 
     result->boss_r_idx = MON_RAPHAEL;
-
-    if (birth_hack || spoiler_hack)
-    {
-        result->subname = NULL;
-        result->subdesc = NULL;
-    }
 
     return result;
 }

--- a/src/defines.h
+++ b/src/defines.h
@@ -685,6 +685,13 @@
 #define DEMON_CYBERDEMON 3
 #define DEMON_MAX        4
 
+#define ASTARTES_ULTRAMARINE   0
+#define ASTARTES_GREY_KNIGHT   1
+#define ASTARTES_BLACK_TEMPLAR 2
+#define ASTARTES_THOUSAND_SONS 3
+#define ASTARTES_BLACK_LEGION  4
+#define ASTARTES_MAX           5
+
 #define DRAGON_RED      0
 #define DRAGON_WHITE    1
 #define DRAGON_BLUE     2

--- a/src/externs.h
+++ b/src/externs.h
@@ -2502,7 +2502,7 @@ extern void set_equip_template(equip_template_ptr new_template);
 
 /* Monster Races */
 extern race_t *mon_angel_get_race(void);
-extern race_t *mon_astartes_get_race(void);
+extern race_t *mon_astartes_get_race(int psubrace);
 extern race_t *mon_beholder_get_race(void);
 extern race_t *mon_centipede_get_race(void);
 extern race_t *mon_demon_get_race(int psubrace);

--- a/src/py_birth.c
+++ b/src/py_birth.c
@@ -50,6 +50,7 @@ extern int py_birth(void);
                     static int _mon_spider_ui(void);
                     static int _mon_troll_ui(void);
                     static int _mon_orc_ui(void);
+                    static int _mon_astartes_ui(void);
         static int _speed_ui(void);
     static int _stats_ui(void);
 
@@ -2195,6 +2196,8 @@ static int _mon_subrace_ui(void)
         return _mon_troll_ui();
     else if (p_ptr->prace == RACE_MON_ORC)
         return _mon_orc_ui();
+    else if (p_ptr->prace == RACE_MON_ASTARTES)
+        return _mon_astartes_ui();
     else
     {
         p_ptr->psubrace = 0;
@@ -2206,6 +2209,12 @@ static int _mon_demon_ui(void)
 {
     assert(p_ptr->prace == RACE_MON_DEMON);
     return _subrace_ui_aux(DEMON_MAX, "Demon Subrace", "Demons.txt", NULL);
+}
+
+static int _mon_astartes_ui(void)
+{
+    assert(p_ptr->prace == RACE_MON_ASTARTES);
+    return _subrace_ui_aux(ASTARTES_MAX, "Astartes Subrace", NULL, NULL);
 }
 
 static int _mon_orc_ui(void)

--- a/src/races.c
+++ b/src/races.c
@@ -177,7 +177,7 @@ race_t *get_race_aux(int prace, int psubrace)
         result = mon_angel_get_race();
         break;
     case RACE_MON_ASTARTES:
-        result = mon_astartes_get_race();
+        result = mon_astartes_get_race(psubrace);
         break;
     case RACE_MON_BEHOLDER:
         result = mon_beholder_get_race();


### PR DESCRIPTION
## Summary
- add chapter constants for Ultramarine, Grey Knight, Black Templar, Thousand Sons and Black Legion
- allow Astartes monster race to select among the new subraces during birth
- hook Astartes subrace choice into race and birth menus

## Testing
- `make -j4` *(fails: No rule to make target 'mk/buildsys.mk')*
- `make -f Makefile.src races.o py_birth.o` *(passes)*
- `make -f Makefile.src astartes.o -B` *(passes)*

------
https://chatgpt.com/codex/tasks/task_e_68c47e09e970832e858715a78b06dc13