### PR TITLE
Add basic Astartes wargear and bolter rifle

### DIFF
--- a/lib/edit/k_info.txt
+++ b/lib/edit/k_info.txt
@@ -1177,6 +1177,15 @@ P:0:x4.00:0:0:0
 A:40/2
 F:SHOW_MODS | TOWN
 
+N:*:& Bolter Rifle~
+G:}:W
+I:19:52:0
+W:25:0:0:150:1200
+P:0:x3.50:0:0:0
+A:25/2
+F:SHOW_MODS
+D:A brutal rifle that fires bolt shells in explosive bursts.
+
 N:*:& Gun~
 G:}:r
 I:19:50:0
@@ -1321,6 +1330,16 @@ F:SHOW_MODS
 F:IGNORE_ACID | IGNORE_COLD | IGNORE_FIRE | IGNORE_ELEC
 M:100:6d7
 
+N:*:& Bolt Shell~
+G:{:W
+I:18:6:0
+W:30:0:0:3:40
+A:30/1
+P:0:4d5:0:0:0
+F:SHOW_MODS
+M:100:6d7
+D:A compact explosive shell designed for bolter rifles.
+
 ########################################################################
 # Shots (TV_SHOT)
 ########################################################################
@@ -1459,6 +1478,14 @@ P:6:1d2:0:2:0
 D:A set of double-lined leather boots, with toes and heels reinforced with
 D:iron, allowing the wearer to deal a swift kick.
 
+N:*:& Pair~ of Astartes Boots
+G:]:W
+I:30:7:0
+W:30:0:0:120:500
+A:30/2
+P:5:1d2:0:1:0
+D:Reinforced power armor boots, heavy yet responsive.
+
 ########################################################################
 #  Helmets (TV_HELM)
 ########################################################################
@@ -1506,6 +1533,14 @@ P:6:1d3:0:0:0
 F:TOWN
 D:This great helm covers the head and shoulders with plates of steel and a
 D:curtain of mail.
+
+N:*:& Astartes Helm~
+G:]:W
+I:32:12:0
+W:35:0:0:120:500
+A:35/2
+P:6:1d3:0:0:0
+D:A sealed helm of power armor, fitted with transhuman auto-senses.
 
 N:*:& Mithril Helm~
 G:]:B
@@ -1620,6 +1655,14 @@ A:10/1
 F:TOWN
 P:4:1d2:1:1:0
 D:A set of gloves that completely covers the hand and wrist in steel plating.
+
+N:*:& Set~ of Astartes Gauntlets
+G:]:W
+I:31:9:0
+W:15:0:0:120:500
+A:15/2
+P:4:1d2:1:1:0
+D:Power armor gauntlets with servo-assisted grips.
 
 N:*:& Set~ of Spiked Gauntlets
 G:]:U
@@ -2079,6 +2122,14 @@ P:50:2d4:-4:0:0
 F:IGNORE_ACID | IGNORE_ELEC | IGNORE_FIRE | IGNORE_COLD
 D:Adamantite, hard as diamonds, forms this exquisite suit; nothing else
 D:in Middle Earth gives as much protection.
+
+N:*:& Astartes Power Armor~
+G:[:W
+I:37:31:0
+W:60:0:0:350:5000
+A:60/3
+P:32:2d4:-2:0:0
+D:Powered ceramite armor with servo-assisted movement and sealed plating.
 
 ########################################################################
 #  Dragon Armor (TV_DRAG_ARMOR)

--- a/src/astartes.c
+++ b/src/astartes.c
@@ -20,10 +20,31 @@ static void _birth(void)
     object_prep(&forge, lookup_kind(TV_POTION, SV_POTION_HEALING));
     py_birth_obj(&forge);
 
-    object_prep(&forge, lookup_kind(TV_SOFT_ARMOR, SV_LEATHER_SCALE_MAIL));
+    object_prep(&forge, lookup_kind(TV_HARD_ARMOR, SV_ASTARTES_POWER_ARMOR));
+    add_flag(forge.flags, OF_NO_REMOVE);
+    add_flag(forge.flags, OF_NO_ENCHANT);
     py_birth_obj(&forge);
 
-    object_prep(&forge, lookup_kind(TV_HAFTED, SV_MACE));
+    object_prep(&forge, lookup_kind(TV_HELM, SV_ASTARTES_HELM));
+    add_flag(forge.flags, OF_NO_REMOVE);
+    add_flag(forge.flags, OF_NO_ENCHANT);
+    py_birth_obj(&forge);
+
+    object_prep(&forge, lookup_kind(TV_GLOVES, SV_SET_OF_ASTARTES_GAUNTLETS));
+    add_flag(forge.flags, OF_NO_REMOVE);
+    add_flag(forge.flags, OF_NO_ENCHANT);
+    py_birth_obj(&forge);
+
+    object_prep(&forge, lookup_kind(TV_BOOTS, SV_PAIR_OF_ASTARTES_BOOTS));
+    add_flag(forge.flags, OF_NO_REMOVE);
+    add_flag(forge.flags, OF_NO_ENCHANT);
+    py_birth_obj(&forge);
+
+    object_prep(&forge, lookup_kind(TV_BOW, SV_BOLTER_RIFLE));
+    py_birth_obj(&forge);
+
+    object_prep(&forge, lookup_kind(TV_BOLT, SV_BOLT_SHELL));
+    forge.number = 30;
     py_birth_obj(&forge);
 
     py_birth_food();

--- a/src/defines.h
+++ b/src/defines.h
@@ -1750,6 +1750,7 @@ enum {
 #define SV_MITHRIL_BOLT  3
 #define SV_SEEKER_BOLT   4
 #define SV_ADAMANTINE_BOLT 5
+#define SV_BOLT_SHELL    6
 
 /* TV_SHOT */
 #define SV_PEBBLE        1
@@ -1767,6 +1768,7 @@ enum {
 #define SV_HEAVY_XBOW                   24
 #define SV_CRIMSON                      50
 #define SV_RAILGUN                      51
+#define SV_BOLTER_RIFLE                 52
 #define SV_NAMAKE_BOW                   63
 #define SV_HARP                         70
 #define SV_FLUTE                        71
@@ -1894,6 +1896,7 @@ enum {
 #define SV_DRAGON_HELM                   8
 #define SV_KABUTO                        9  /* 9 */
 #define SV_POINTY_HAT                   10
+#define SV_ASTARTES_HELM                12
 
 /* The "sval" codes for TV_CROWN */
 #define SV_IRON_CROWN                   10
@@ -1907,6 +1910,7 @@ enum {
 #define SV_PAIR_OF_DRAGON_GREAVE         4
 #define SV_PAIR_OF_METAL_SHOD_BOOTS      5
 #define SV_PAIR_OF_MITHRIL_SHOD_BOOTS    6
+#define SV_PAIR_OF_ASTARTES_BOOTS        7
 
 /* The "sval" codes for TV_CLOAK */
 #define SV_CLOAK                         1
@@ -1925,6 +1929,7 @@ enum {
 #define SV_SET_OF_DRAGON_GLOVES          6
 #define SV_SET_OF_CESTI                  7
 #define SV_HAND                          8
+#define SV_SET_OF_ASTARTES_GAUNTLETS     9
 
 /* The "sval" codes for TV_SOFT_ARMOR */
 #define SV_T_SHIRT                       0
@@ -1968,6 +1973,7 @@ enum {
 #define SV_MITHRIL_CHAIN_MAIL           20  /* 28+ */
 #define SV_MITHRIL_PLATE_MAIL           25  /* 35+ */
 #define SV_ADAMANTITE_PLATE_MAIL        30  /* 40+ */
+#define SV_ASTARTES_POWER_ARMOR         31  /* 25+ */
 
 /* The "sval" codes for TV_DRAG_ARMOR */
 #define SV_DRAGON_BLACK                  1

--- a/src/obj.c
+++ b/src/obj.c
@@ -386,13 +386,13 @@ bool obj_is_harp(obj_ptr obj)
 bool obj_is_gun(obj_ptr obj)
 {
     if (!obj_is_shooter(obj)) return FALSE;
-    if (obj->sval != SV_CRIMSON && obj->sval != SV_RAILGUN) return FALSE;
+    if (obj->sval != SV_CRIMSON && obj->sval != SV_RAILGUN && obj->sval != SV_BOLTER_RIFLE) return FALSE;
     return TRUE;
 }
 bool obj_is_fake_bow(obj_ptr obj)
 {
     if (!obj_is_shooter(obj)) return FALSE;
-    if (obj->sval != SV_HARP && obj->sval != SV_FLUTE && obj->sval != SV_CRIMSON && obj->sval != SV_RAILGUN) return FALSE;
+    if (obj->sval != SV_HARP && obj->sval != SV_FLUTE && obj->sval != SV_CRIMSON && obj->sval != SV_RAILGUN && obj->sval != SV_BOLTER_RIFLE) return FALSE;
     return TRUE;
 }
 /************************************************************************

--- a/src/xtra1.c
+++ b/src/xtra1.c
@@ -4860,6 +4860,11 @@ void calc_bonuses(void)
                 p_ptr->shooter_info.tval_ammo = TV_BOLT;
                 break;
             }
+            case SV_BOLTER_RIFLE:
+            {
+                p_ptr->shooter_info.tval_ammo = TV_BOLT;
+                break;
+            }
             case SV_CRIMSON:
             case SV_RAILGUN:
             case SV_HARP:


### PR DESCRIPTION
### Motivation
- Provide placeholder sub-race gear for the Astartes with a simple starter loadout (power-armor set + ranged weapon + ammo) so the race can be played and iterated on later.

### Description
- Add new svals in `src/defines.h` for Astartes items and bolter support (`SV_ASTARTES_HELM`, `SV_PAIR_OF_ASTARTES_BOOTS`, `SV_SET_OF_ASTARTES_GAUNTLETS`, `SV_ASTARTES_POWER_ARMOR`, `SV_BOLT_SHELL`, `SV_BOLTER_RIFLE`).
- Add k_info entries in `lib/edit/k_info.txt` for `Astartes Power Armor`, `Astartes Helm`, `Astartes Boots`, `Astartes Gauntlets`, `Bolter Rifle`, and `Bolt Shell` (item templates and basic stats/descriptions).
- Update Astartes birth code in `src/astartes.c` to equip the player with non-removable, non-enchantable power armor pieces plus a bolter rifle and 30 bolt shells as the starting loadout.
- Wire bolter rifle support into game logic by treating `SV_BOLTER_RIFLE` as a gun in `src/obj.c` and by assigning `TV_BOLT` ammo for the bolter in `src/xtra1.c` so the shooter subsystem accepts bolt-shell ammo.

### Testing
- No automated tests were run on the modified code (no compile/unit tests executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985315e4818832ea6f020a32994808a)